### PR TITLE
Add timeout to Provide call

### DIFF
--- a/simple/provider.go
+++ b/simple/provider.go
@@ -88,8 +88,15 @@ func (p *Provider) handleAnnouncements() {
 				case <-p.ctx.Done():
 					return
 				case c := <-p.queue.Dequeue():
-					ctx, cancel := context.WithTimeout(p.ctx, p.timeout)
-					defer cancel()
+					var ctx context.Context
+					var cancel context.CancelFunc
+					if p.timeout > 0 {
+						ctx, cancel = context.WithTimeout(p.ctx, p.timeout)
+						defer cancel()
+					} else {
+						ctx = p.ctx
+					}
+
 					logP.Info("announce - start - ", c)
 					if err := p.contentRouting.Provide(ctx, c, true); err != nil {
 						logP.Warningf("Unable to provide entry: %s, %s", c, err)


### PR DESCRIPTION
This just adds the the ability to set a timeout that is used by [go-bitswap](https://github.com/ipfs/go-bitswap/blob/master/workers.go#L126) when doing a `Provide`. Partially addresses https://github.com/ipfs/go-ipfs-provider/issues/7.

This also makes the worker count configurable.