### PR TITLE
log keyProvider failure as an error

### DIFF
--- a/simple/reprovide.go
+++ b/simple/reprovide.go
@@ -77,7 +77,7 @@ func (rp *Reprovider) Run() {
 
 		err := rp.Reprovide()
 		if err != nil {
-			logR.Debug(err)
+			logR.Errorf("failed to reprovide: %s", err)
 		}
 
 		if done != nil {


### PR DESCRIPTION
If an error bubble up here, the Reprovider is effectively disabled. Error level is justified IMHO.