### PR TITLE
PinnedProvider: match the updated Pinner interface

### DIFF
--- a/simple/provider.go
+++ b/simple/provider.go
@@ -24,7 +24,7 @@ type Provider struct {
 	contentRouting routing.ContentRouting
 	// how long to wait for announce to complete before giving up
 	timeout time.Duration
-	// how many workers concurrently work through thhe queue
+	// how many workers concurrently work through the queue
 	workerLimit int
 }
 

--- a/simple/reprovide_test.go
+++ b/simple/reprovide_test.go
@@ -100,12 +100,12 @@ type mockPinner struct {
 	direct    []cid.Cid
 }
 
-func (mp *mockPinner) DirectKeys() []cid.Cid {
-	return mp.direct
+func (mp *mockPinner) DirectKeys(_ context.Context) ([]cid.Cid, error) {
+	return mp.direct, nil
 }
 
-func (mp *mockPinner) RecursiveKeys() []cid.Cid {
-	return mp.recursive
+func (mp *mockPinner) RecursiveKeys(_ context.Context) ([]cid.Cid, error) {
+	return mp.recursive, nil
 }
 
 func TestReprovidePinned(t *testing.T) {


### PR DESCRIPTION
Follow the changes of https://github.com/ipfs/go-ipfs/pull/6715

This could also be done by simply importing `go-ipfs-pinner` now that it's its own package.