### PR TITLE
Concurrent reprovide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ import (
 	"time"
 
 	"github.com/ipfs/go-ipfs-provider"
+	"github.com/ipfs/go-ipfs-provider/provider"
 	"github.com/ipfs/go-ipfs-provider/queue"
-	"github.com/ipfs/go-ipfs-provider/simple"
+	"github.com/ipfs/go-ipfs-provider/reprovider"
 )
 
 rsys := (your routing system here)
@@ -40,8 +41,8 @@ cid := (your cid to provide here)
 
 q := queue.NewQueue(context.Background(), "example", dstore)
 
-reprov := simple.NewReprovider(context.Background(), time.Hour * 12, rsys, simple.NewBlockstoreProvider)
-prov := simple.NewProvider(context.Background(), q, rsys)
+reprov := sreprov.NewReprovider(context.Background(), time.Hour*12, rsys, sreprov.NewBlockstoreProvider)
+prov := sprov.NewProvider(context.Background(), q, rsys)
 sys := provider.NewSystem(prov, reprov)
 
 sys.Run()

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ import (
 	"time"
 
 	"github.com/ipfs/go-ipfs-provider"
-	"github.com/ipfs/go-ipfs-provider/provider"
+	sprov "github.com/ipfs/go-ipfs-provider/provider"
 	"github.com/ipfs/go-ipfs-provider/queue"
-	"github.com/ipfs/go-ipfs-provider/reprovider"
+	sreprov "github.com/ipfs/go-ipfs-provider/reprovider"
 )
 
 rsys := (your routing system here)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,7 +1,7 @@
-// Package simple implements structures and methods to provide blocks,
+// Package sprov implements structures and methods to provide blocks,
 // keep track of which blocks are provided, and to allow those blocks to
 // be reprovided.
-package simple
+package sprov
 
 import (
 	"context"
@@ -24,7 +24,7 @@ type Provider struct {
 	contentRouting routing.ContentRouting
 	// how long to wait for announce to complete before giving up
 	timeout time.Duration
-	// how many workers concurrently work through thhe queue
+	// how many workers concurrently work through the queue
 	workerLimit int
 }
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1,4 +1,4 @@
-package simple_test
+package sprov_test
 
 import (
 	"context"
@@ -14,7 +14,7 @@ import (
 
 	q "github.com/ipfs/go-ipfs-provider/queue"
 
-	. "github.com/ipfs/go-ipfs-provider/simple"
+	. "github.com/ipfs/go-ipfs-provider/provider"
 )
 
 var blockGenerator = blocksutil.NewBlockGenerator()

--- a/reprovider/reprovide.go
+++ b/reprovider/reprovide.go
@@ -1,4 +1,4 @@
-package simple
+package sreprov
 
 import (
 	"context"

--- a/reprovider/reprovide_test.go
+++ b/reprovider/reprovide_test.go
@@ -1,4 +1,4 @@
-package simple_test
+package sreprov_test
 
 import (
 	"context"
@@ -18,7 +18,7 @@ import (
 	testutil "github.com/libp2p/go-libp2p-testing/net"
 	mh "github.com/multiformats/go-multihash"
 
-	. "github.com/ipfs/go-ipfs-provider/simple"
+	. "github.com/ipfs/go-ipfs-provider/reprovider"
 )
 
 func setupRouting(t *testing.T) (clA, clB mock.Client, idA, idB peer.ID) {


### PR DESCRIPTION
This PR:
- split the provider and the reprovider into their own respective package to avoid name collision when they both have a set of functional options
- implement concurrent publishing in the reprovider