### PR TITLE
Fix several race on close bugs

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -132,7 +132,7 @@ func (q *Queue) work() {
 	}()
 }
 
-func (q *Queue) getQueueHead() (*query.Result, error) {
+func (q *Queue) getQueueHead() (*query.Entry, error) {
 	qry := query.Query{Orders: []query.Order{query.OrderByKey{}}, Limit: 1}
 	results, err := q.ds.Query(qry)
 	if err != nil {
@@ -144,5 +144,5 @@ func (q *Queue) getQueueHead() (*query.Result, error) {
 		return nil, nil
 	}
 
-	return &r, nil
+	return &r.Entry, r.Error
 }

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -80,17 +80,17 @@ func (q *Queue) work() {
 
 		for {
 			if c == cid.Undef {
-				head, e := q.getQueueHead()
+				head, err := q.getQueueHead()
 
-				if e != nil {
-					log.Errorf("error querying for head of queue: %s, stopping provider", e)
+				if err != nil {
+					log.Errorf("error querying for head of queue: %s, stopping provider", err)
 					return
 				} else if head != nil {
 					k = datastore.NewKey(head.Key)
-					c, e = cid.Parse(head.Value)
-					if e != nil {
-						log.Warningf("error parsing queue entry cid with key (%s), removing it from queue: %s", head.Key, e)
-						err := q.ds.Delete(k)
+					c, err = cid.Parse(head.Value)
+					if err != nil {
+						log.Warningf("error parsing queue entry cid with key (%s), removing it from queue: %s", head.Key, err)
+						err = q.ds.Delete(k)
 						if err != nil {
 							log.Errorf("error deleting queue entry with key (%s), due to error (%s), stopping provider", head.Key, err)
 							return


### PR DESCRIPTION
* Return errors from enqueue when we fail.
* Handle errors inside query results (first error in https://github.com/ipfs/go-ipfs/issues/6985).