### PR TITLE
fix: handle closed queue

### DIFF
--- a/simple/provider.go
+++ b/simple/provider.go
@@ -85,7 +85,12 @@ func (p *Provider) handleAnnouncements() {
 				select {
 				case <-p.ctx.Done():
 					return
-				case c := <-p.queue.Dequeue():
+				case c, ok := <-p.queue.Dequeue():
+					if !ok {
+						// queue closed.
+						return
+					}
+
 					p.doProvide(c)
 				}
 			}


### PR DESCRIPTION
When the queue closes, return instead of providing empty CIDs.