### PR TITLE
fix several bugs

### DIFF
--- a/simple/reprovide.go
+++ b/simple/reprovide.go
@@ -142,7 +142,7 @@ func (rp *Reprovider) Reprovide() error {
 	return nil
 }
 
-// Trigger starts reprovision process in rp.Run and waits for it to finish.
+// Trigger starts the reprovision process in rp.Run and waits for it to finish.
 //
 // Returns an error if a reprovide is already in progress.
 func (rp *Reprovider) Trigger(ctx context.Context) error {

--- a/simple/reprovide.go
+++ b/simple/reprovide.go
@@ -20,12 +20,16 @@ var logR = logging.Logger("reprovider.simple")
 
 // KeyChanFunc is function streaming CIDs to pass to content routing
 type KeyChanFunc func(context.Context) (<-chan cid.Cid, error)
-type doneFunc func(error)
 
 // Reprovider reannounces blocks to the network
 type Reprovider struct {
-	ctx     context.Context
-	trigger chan doneFunc
+	// Reprovider context. Cancel to stop, then wait on doneCh.
+	ctx    context.Context
+	cancel context.CancelFunc
+	doneCh chan struct{}
+
+	// Trigger triggers a reprovide.
+	trigger chan chan<- error
 
 	// The routing system to provide values through
 	rsys routing.ContentRouting
@@ -37,9 +41,12 @@ type Reprovider struct {
 
 // NewReprovider creates new Reprovider instance.
 func NewReprovider(ctx context.Context, reprovideIniterval time.Duration, rsys routing.ContentRouting, keyProvider KeyChanFunc) *Reprovider {
+	ctx, cancel := context.WithCancel(ctx)
 	return &Reprovider{
 		ctx:     ctx,
-		trigger: make(chan doneFunc),
+		cancel:  cancel,
+		doneCh:  make(chan struct{}),
+		trigger: make(chan chan<- error),
 
 		rsys:        rsys,
 		keyProvider: keyProvider,
@@ -49,44 +56,60 @@ func NewReprovider(ctx context.Context, reprovideIniterval time.Duration, rsys r
 
 // Close the reprovider
 func (rp *Reprovider) Close() error {
+	rp.cancel()
+	<-rp.doneCh
 	return nil
 }
 
 // Run re-provides keys with 'tick' interval or when triggered
 func (rp *Reprovider) Run() {
-	// dont reprovide immediately.
-	// may have just started the daemon and shutting it down immediately.
-	// probability( up another minute | uptime ) increases with uptime.
-	after := time.After(time.Minute)
-	var done doneFunc
-	for {
-		if rp.tick == 0 {
-			after = make(chan time.Time)
-		}
+	defer close(rp.doneCh)
 
+	var initialReprovideCh, reprovideCh <-chan time.Time
+
+	// If reproviding is enabled (non-zero)
+	if rp.tick > 0 {
+		reprovideTicker := time.NewTicker(rp.tick)
+		defer reprovideTicker.Stop()
+		reprovideCh = reprovideTicker.C
+
+		// If the reprovide ticker is larger than a minute (likely),
+		// provide once after we've been up a minute.
+		//
+		// Don't provide _immediately_ as we might be just about to stop.
+		if rp.tick > time.Minute {
+			initialReprovideTimer := time.NewTimer(time.Minute)
+			defer initialReprovideTimer.Stop()
+
+			initialReprovideCh = initialReprovideTimer.C
+		}
+	}
+
+	var done chan<- error
+	for rp.ctx.Err() == nil {
 		select {
+		case <-initialReprovideCh:
+		case <-reprovideCh:
+		case done = <-rp.trigger:
 		case <-rp.ctx.Done():
 			return
-		case done = <-rp.trigger:
-		case <-after:
 		}
 
-		//'mute' the trigger channel so when `ipfs bitswap reprovide` is called
-		//a 'reprovider is already running' error is returned
-		unmute := rp.muteTrigger()
-
 		err := rp.Reprovide()
-		if err != nil {
+
+		// only log if we've hit an actual error, otherwise just tell the client we're shutting down
+		if rp.ctx.Err() != nil {
+			err = fmt.Errorf("shutting down")
+		} else if err != nil {
 			logR.Errorf("failed to reprovide: %s", err)
 		}
 
 		if done != nil {
-			done(err)
+			if err != nil {
+				done <- err
+			}
+			close(done)
 		}
-
-		unmute()
-
-		after = time.After(rp.tick)
 	}
 }
 
@@ -119,42 +142,25 @@ func (rp *Reprovider) Reprovide() error {
 	return nil
 }
 
-// Trigger starts reprovision process in rp.Run and waits for it
+// Trigger starts reprovision process in rp.Run and waits for it to finish.
+//
+// Returns an error if a reprovide is already in progress.
 func (rp *Reprovider) Trigger(ctx context.Context) error {
-	progressCtx, done := context.WithCancel(ctx)
-
-	var err error
-	df := func(e error) {
-		err = e
-		done()
+	doneCh := make(chan error, 1)
+	select {
+	case rp.trigger <- doneCh:
+	default:
+		return fmt.Errorf("reprovider is already running")
 	}
 
 	select {
-	case <-rp.ctx.Done():
-		return context.Canceled
-	case <-ctx.Done():
-		return context.Canceled
-	case rp.trigger <- df:
-		<-progressCtx.Done()
+	case err := <-doneCh:
 		return err
+	case <-rp.ctx.Done():
+		return fmt.Errorf("reprovide service stopping")
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-}
-
-func (rp *Reprovider) muteTrigger() context.CancelFunc {
-	ctx, cf := context.WithCancel(rp.ctx)
-	go func() {
-		defer cf()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case done := <-rp.trigger:
-				done(fmt.Errorf("reprovider is already running"))
-			}
-		}
-	}()
-
-	return cf
 }
 
 // Strategies

--- a/simple/reprovide_test.go
+++ b/simple/reprovide_test.go
@@ -147,9 +147,13 @@ func TestTriggerTwice(t *testing.T) {
 	// Wait for the trigger to really start.
 	startCh <- struct{}{}
 
+	start := time.Now()
 	// Try to trigger again, this should fail immediately.
 	if err := reprov.Trigger(ctx); err == nil {
 		t.Fatal("expected an error")
+	}
+	if time.Since(start) > 10*time.Millisecond {
+		t.Fatal("expected reprovide to fail instantly")
 	}
 
 	// Let the trigger progress.


### PR DESCRIPTION
1. Don't log an error when shutting down while reproviding.
2. Reprovide on a fixed interval instead of treating the interval as a delay.
3. Remove trigger muting logic and use the simpler way.
4. Add some tests for triggering.
5. Make sure Reprovider.Close actually, you know, does something. And waits for the reprovider to stop.