### PR TITLE
chore: update the Usage part of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cid := (your cid to provide here)
 
 q := queue.NewQueue(context.Background(), "example", dstore)
 
-reprov := simple.NewReprovider(context.Background(), time.Hour * 12, rsys, simple.NewBlockstoreProvider)
+reprov := simple.NewReprovider(context.Background(), time.Hour * 12, rsys, simple.NewBlockstoreProvider(dstore))
 prov := simple.NewProvider(context.Background(), q, rsys)
 sys := provider.NewSystem(prov, reprov)
 


### PR DESCRIPTION
The `Usage` part of readme missed the parameter for `simple.NewBlockstoreProvider()`