### PR TITLE
Fix go vet and staticcheck

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -96,7 +96,7 @@ func (q *Queue) work() {
 					k = datastore.NewKey(head.Key)
 					c, err = cid.Parse(head.Value)
 					if err != nil {
-						log.Warningf("error parsing queue entry cid with key (%s), removing it from queue: %s", head.Key, err)
+						log.Warnf("error parsing queue entry cid with key (%s), removing it from queue: %s", head.Key, err)
 						err = q.ds.Delete(q.ctx, k)
 						if err != nil {
 							log.Errorf("error deleting queue entry with key (%s), due to error (%s), stopping provider", head.Key, err)

--- a/simple/provider.go
+++ b/simple/provider.go
@@ -110,7 +110,7 @@ func (p *Provider) doProvide(c cid.Cid) {
 
 	logP.Info("announce - start - ", c)
 	if err := p.contentRouting.Provide(ctx, c, true); err != nil {
-		logP.Warningf("Unable to provide entry: %s, %s", c, err)
+		logP.Warnf("Unable to provide entry: %s, %s", c, err)
 	}
 	logP.Info("announce - end - ", c)
 }

--- a/simple/reprovide.go
+++ b/simple/reprovide.go
@@ -236,7 +236,7 @@ func pinSet(ctx context.Context, pinning Pinner, fetchConfig fetcher.Factory, on
 		for _, key := range rkeys {
 			set.Visitor(ctx)(key)
 			if !onlyRoots {
-				err := fetcherhelpers.BlockAll(ctx, session, cidlink.Link{key}, func(res fetcher.FetchResult) error {
+				err := fetcherhelpers.BlockAll(ctx, session, cidlink.Link{Cid: key}, func(res fetcher.FetchResult) error {
 					clink, ok := res.LastBlockLink.(cidlink.Link)
 					if ok {
 						set.Visitor(ctx)(clink.Cid)


### PR DESCRIPTION
This PR fixes errors reported by `go vet ./...` and `staticcheck ./...`.

It is one of the prerequisites for enabling automated CI on the repository - https://github.com/ipfs/go-ipfs-provider/pull/36