### PR TITLE
fix: make queue 64bits on 32bits platforms too

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -28,7 +28,7 @@ type Queue struct {
 	close   context.CancelFunc
 	closed  chan struct{}
 
-	counter int
+	counter uint64
 }
 
 // NewQueue creates a queue for cids
@@ -117,7 +117,7 @@ func (q *Queue) work() {
 
 			select {
 			case toQueue := <-q.enqueue:
-				keyPath := fmt.Sprintf("%063d/%s", q.counter, c.String())
+				keyPath := fmt.Sprintf("%020d/%s", q.counter, c.String())
 				q.counter++
 				nextKey := datastore.NewKey(keyPath)
 

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.8.0"
+  "version": "v0.8.1"
 }


### PR DESCRIPTION
`int` is 32bits on 32bits platforms, it is realistical that you would overflow it (afaik by having more than 2b blocks in one datastore)
Also we don't need 63 leading digits, a uint64 can always be represented in 20 base 10 digits.

Fix bug introduced in 53fe9d84caf3f92f665932ff2f3c246ed0288466.